### PR TITLE
Improve README and fix edge width

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ The script will run `ITERATIONS` cycles:
 
 To integrate your own feedback streams, replace the `suggestion_pool` and `opinion_pool` lists or modify the feedback‑appending logic in `main()`.
 
+## Troubleshooting
+
+If the script fails to download the `sentence-transformers` model or connect to
+Openrouter, check that your environment allows outbound HTTPS traffic and that
+`OPENROUTER_API_KEY` is correctly set. You can also provide a local model path
+by editing `EMBED_MODEL` in `fb_graph.py`.
+
 ## Configuration
 
 Edit these constants at the top of `fb_graph.py` as needed:

--- a/fb_graph.py
+++ b/fb_graph.py
@@ -209,6 +209,7 @@ def plot_graph(G, centers, ax, title):
         sim = d["weight"]
         # scale thickness
         w   = MIN_EDGE_WIDTH + (sim - SIM_THRESHOLD) / (1 - SIM_THRESHOLD) * (MAX_EDGE_WIDTH - MIN_EDGE_WIDTH)
+        w   = max(MIN_EDGE_WIDTH, w)
         edge_list.append((u, v))
         widths.append(w)
     nx.draw_networkx_edges(


### PR DESCRIPTION
## Summary
- fix negative edge width when similarities are below the threshold
- add troubleshooting tips to the README

## Testing
- `flake8 fb_graph.py`
- `python -m py_compile fb_graph.py`
- `python fb_graph.py` *(fails: ProxyError when downloading model)*

------
https://chatgpt.com/codex/tasks/task_e_684bc649150483288f825102b759aab5